### PR TITLE
Improves assertion failure reporting and test coverage

### DIFF
--- a/AssertAll.Tests/AssertAll.Tests.csproj
+++ b/AssertAll.Tests/AssertAll.Tests.csproj
@@ -32,10 +32,4 @@
     <ProjectReference Include="..\AssertAll\AssertAll.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="AssertAll">
-      <HintPath>..\..\..\..\.nuget\packages\assertall\3.0.0\lib\netstandard2.0\AssertAll.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>

--- a/AssertAll.Tests/AssertAllTests/AreEqualShould.cs
+++ b/AssertAll.Tests/AssertAllTests/AreEqualShould.cs
@@ -1,6 +1,7 @@
 using AssertAllNuget;
 using AssertAllNuget.Exceptions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.RegularExpressions;
 
 namespace AssertAllTests.AssertAllTests
 {
@@ -8,21 +9,17 @@ namespace AssertAllTests.AssertAllTests
     public class AreEqualShould : TestBase
     {
         [TestMethod]
-        public void FailWhenNotEqual()
+        [DataRow(1, 2, "1 and 2 are not equal, ya dummy", DisplayName = "Fail when not equal")]
+        [DataRow(1, 1L, "the types are different", DisplayName = "Fail when logically equal but different types")]
+        public void FailWhenNotExactlyEqual(
+                object expected, object actual, string message)
         {
-            AssertAll.AreEqual(1, 2, "1 and 2 are not equal, ya dummy");
-            
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
-        }
+            AssertAll.AreEqual(expected, actual, message);
 
-        [TestMethod]
-        public void FailWhenLogicallyEqualButDifferentTypes()
-        {
-            int expected = 1;
-            long actual = 1;
-            AssertAll.AreEqual(expected, actual, "the types are different");
-
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.AreEqual", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]

--- a/AssertAll.Tests/AssertAllTests/AreNotEqualShould.cs
+++ b/AssertAll.Tests/AssertAllTests/AreNotEqualShould.cs
@@ -28,9 +28,13 @@ namespace AssertAllTests.AssertAllTests
         [TestMethod]
         public void FailWhenEqual()
         {
-            AssertAll.AreNotEqual(1, 1, "1 and 1 are indeed the same");
+            string message = "1 and 1 are indeed the same";
+            AssertAll.AreNotEqual(1, 1, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.AreNotEqual", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/AssertAllTests/AreNotSameShould.cs
+++ b/AssertAll.Tests/AssertAllTests/AreNotSameShould.cs
@@ -21,10 +21,14 @@ namespace AssertAllTests.AssertAllTests
         {
             var object1 = new object();
             var object2 = object1;
+            string message = "these are the same";
 
-            AssertAll.AreNotSame(object1, object2, "these are the same");
+            AssertAll.AreNotSame(object1, object2, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.AreNotSame", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/AssertAllTests/AreSameShould.cs
+++ b/AssertAll.Tests/AssertAllTests/AreSameShould.cs
@@ -21,10 +21,14 @@ namespace AssertAllTests.AssertAllTests
         {
             var object1 = new object();
             var object2 = new object();
+            string message = "these are not the same";
 
-            AssertAll.AreSame(object1, object2, "these are not the same");
+            AssertAll.AreSame(object1, object2, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.AreSame", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/AssertAllTests/FailShould.cs
+++ b/AssertAll.Tests/AssertAllTests/FailShould.cs
@@ -10,9 +10,13 @@ namespace AssertAllTests.AssertAllTests
         [TestMethod]
         public void Fail()
         {
-            AssertAll.Fail();
+            string message = "forced failure";
+            AssertAll.Fail(message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Fail", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/AssertAllTests/InconclusiveShould.cs
+++ b/AssertAll.Tests/AssertAllTests/InconclusiveShould.cs
@@ -10,9 +10,13 @@ namespace AssertAllTests.AssertAllTests
         [TestMethod]
         public void ThrowAssertInconclusiveException()
         {
-            AssertAll.Inconclusive("the test is inconclusive");
+            string message = "the test is inconclusive";
+            AssertAll.Inconclusive(message);
 
-            Assert.ThrowsException<AssertAllInconclusiveException>(() => AssertAll.Execute());
+            AssertAllInconclusiveException ex =
+                    Assert.ThrowsException<AssertAllInconclusiveException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Inconclusive", "Warning message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Warning message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/AssertAllTests/IsFalseShould.cs
+++ b/AssertAll.Tests/AssertAllTests/IsFalseShould.cs
@@ -18,9 +18,13 @@ namespace AssertAllTests.AssertAllTests
         [TestMethod]
         public void FailWhenTrue()
         {
-            AssertAll.IsFalse(true, "1 and 2 are the same");
+            string message = "true is false, Winston";
+            AssertAll.IsFalse(true, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.IsFalse", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/AssertAllTests/IsInstanceOfTypeShould.cs
+++ b/AssertAll.Tests/AssertAllTests/IsInstanceOfTypeShould.cs
@@ -17,9 +17,14 @@ namespace AssertAllTests.AssertAllTests
         [TestMethod]
         public void FailWhenTypesAreNotTheSame()
         {
-            AssertAll.IsInstanceOfType("1", typeof(int));
+            string message = "a string is not an int";
+            AssertAll.IsInstanceOfType("1", typeof(int), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.IsInstanceOfType", "Failure message assertion name was not altered");
+            StringAssert.Contains(ex.Message, message, "Failure message missing");
+            StringAssert.EndsWith(ex.Message, ">.", "Failure message followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/AssertAllTests/IsNotInstanceOfType.cs
+++ b/AssertAll.Tests/AssertAllTests/IsNotInstanceOfType.cs
@@ -17,9 +17,13 @@ namespace AssertAllTests.AssertAllTests
         [TestMethod]
         public void FailWhenTypesAreNotTheSame()
         {
-            AssertAll.IsNotInstanceOfType(1, typeof(int));
+            string message = "an int is an int";
+            AssertAll.IsNotInstanceOfType(1, typeof(int), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.IsNotInstanceOfType", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/AssertAllTests/IsNotNullShould.cs
+++ b/AssertAll.Tests/AssertAllTests/IsNotNullShould.cs
@@ -17,9 +17,13 @@ namespace AssertAllTests.AssertAllTests
         [TestMethod]
         public void FailWhenNotNull()
         {
-            AssertAll.IsNotNull(null);
+            string message = "value is null";
+            AssertAll.IsNotNull(null, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.IsNotNull", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/AssertAllTests/IsNullShould.cs
+++ b/AssertAll.Tests/AssertAllTests/IsNullShould.cs
@@ -17,9 +17,13 @@ namespace AssertAllTests.AssertAllTests
         [TestMethod]
         public void FailWhenNotNull()
         {
-            AssertAll.IsNull(1);
+            string message = "value is not null";
+            AssertAll.IsNull(1, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.IsNull", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/AssertAllTests/IsTrueShould.cs
+++ b/AssertAll.Tests/AssertAllTests/IsTrueShould.cs
@@ -10,7 +10,7 @@ namespace AssertAllTests.AssertAllTests
         [TestMethod]
         public void PassWhenTrue()
         {
-            AssertAll.IsTrue(true, "1 and 1 are indeed the same");
+            AssertAll.IsTrue(true, "oh dear, true is no longer true");
 
             AssertAll.Execute();
         }
@@ -18,9 +18,13 @@ namespace AssertAllTests.AssertAllTests
         [TestMethod]
         public void FailWhenFalse()
         {
-            AssertAll.IsTrue(1 == 2, "1 and 2 are not the same ya dummy");
+            string message = "1 and 2 are not the same ya dummy";
+            AssertAll.IsTrue(1 == 2, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.IsTrue", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/AssertAllTests/ThrowsExceptionAsyncShould.cs
+++ b/AssertAll.Tests/AssertAllTests/ThrowsExceptionAsyncShould.cs
@@ -19,17 +19,25 @@ namespace AssertAllTests.AssertAllTests
         [TestMethod]
         public void FailWhenNoExceptionIsThrown()
         {
-            AssertAll.ThrowsExceptionAsync<NotImplementedException>(async () => await ThrowContrivedException(false));
+            string message = "exception not thrown";
+            AssertAll.ThrowsExceptionAsync<NotImplementedException>(async () => await ThrowContrivedException(false), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.ThrowsException", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]
         public void FailWhenWrongExceptionIsThrown()
         {
-            AssertAll.ThrowsExceptionAsync<NullReferenceException>(async () => await ThrowContrivedException(true));
+            string message = "incorrect exception thrown";
+            AssertAll.ThrowsExceptionAsync<NullReferenceException>(async () => await ThrowContrivedException(true), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.ThrowsException", "Failure message assertion name was not altered");
+            StringAssert.Contains(ex.Message, $"{message}{Environment.NewLine}Exception Message:", "Failure message missing or followed by unexpected text");
         }
 
         private static async Task ThrowContrivedException(bool throwException)

--- a/AssertAll.Tests/AssertAllTests/ThrowsExceptionShould.cs
+++ b/AssertAll.Tests/AssertAllTests/ThrowsExceptionShould.cs
@@ -23,18 +23,26 @@ namespace AssertAllTests.AssertAllTests
         public void FailWhenNoExceptionIsThrown()
         {
             var list = new List<object>{new object()};
-            AssertAll.ThrowsException<InvalidOperationException>(() => list.Single());
+            string message = "exception not thrown";
+            AssertAll.ThrowsException<InvalidOperationException>(() => list.Single(), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.ThrowsException", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]
         public void FailWhenWrongExceptionIsThrown()
         {
             var emptyList = new List<object>();
-            AssertAll.ThrowsException<NullReferenceException>(() => emptyList.Single());
+            string message = "incorrect exception thrown";
+            AssertAll.ThrowsException<NullReferenceException>(() => emptyList.Single(), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.ThrowsException", "Failure message assertion name was not altered");
+            StringAssert.Contains(ex.Message, $"{message}{Environment.NewLine}Exception Message:", "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/CollectionTests/AllItemsAreInstancesOfTypeShould.cs
+++ b/AssertAll.Tests/CollectionTests/AllItemsAreInstancesOfTypeShould.cs
@@ -12,9 +12,13 @@ namespace AssertAllTests.CollectionTests
         public void FailWhenNotOfType()
         {
             var list1 = new List<string> {"1"};
-            AssertAll.Collections.AllItemsAreInstancesOfType(list1, typeof(char));
+            string message = "list contains items of wrong type";
+            AssertAll.Collections.AllItemsAreInstancesOfType(list1, typeof(char), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Collections.AllItemsAreInstancesOfType", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]
@@ -29,9 +33,13 @@ namespace AssertAllTests.CollectionTests
         public void FailWhenParentType()
         {
             var list1 = new List<ParentType> { new ParentType() };
-            AssertAll.Collections.AllItemsAreInstancesOfType(list1, typeof(ChildType));
+            string message = "list contains items of wrong type";
+            AssertAll.Collections.AllItemsAreInstancesOfType(list1, typeof(ChildType), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Collections.AllItemsAreInstancesOfType", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]

--- a/AssertAll.Tests/CollectionTests/AllItemsAreNotNullShould.cs
+++ b/AssertAll.Tests/CollectionTests/AllItemsAreNotNullShould.cs
@@ -12,9 +12,13 @@ namespace AssertAllTests.CollectionTests
         public void FailWhenItemIsNull()
         {
             var list1 = new List<string> {null};
-            AssertAll.Collections.AllItemsAreNotNull(list1);
+            string message = "list contains null items";
+            AssertAll.Collections.AllItemsAreNotNull(list1, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Collections.AllItemsAreNotNull", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]

--- a/AssertAll.Tests/CollectionTests/AllItemsAreUniqueShould.cs
+++ b/AssertAll.Tests/CollectionTests/AllItemsAreUniqueShould.cs
@@ -12,9 +12,13 @@ namespace AssertAllTests.CollectionTests
         public void FailWhenItemsNotUnique()
         {
             var list1 = new List<string> {"1", "1"};
-            AssertAll.Collections.AllItemsAreUnique(list1);
+            string message = "list contains duplicate items";
+            AssertAll.Collections.AllItemsAreUnique(list1, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Collections.AllItemsAreUnique", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]

--- a/AssertAll.Tests/CollectionTests/AreEqualShould.cs
+++ b/AssertAll.Tests/CollectionTests/AreEqualShould.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using AssertAllNuget;
 using AssertAllNuget.Exceptions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -13,9 +14,13 @@ namespace AssertAllTests.CollectionTests
         {
             var list1 = new List<string> {"1"};
             var list2 = new List<string> {"1", "2"};
-            AssertAll.Collections.AreEqual(list1, list2);
+            string message = "list items are different";
+            AssertAll.Collections.AreEqual(list1, list2, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Collections.AreEqual", "Failure message assertion name was not altered");
+            StringAssert.Matches(ex.Message, new Regex($".+{message}\\(.+\\.\\)$"), "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]
@@ -23,9 +28,13 @@ namespace AssertAllTests.CollectionTests
         {
             var list1 = new List<string> { "2", "1" };
             var list2 = new List<string> { "1", "2" };
-            AssertAll.Collections.AreEqual(list1, list2);
+            string message = "list items are different or in different order";
+            AssertAll.Collections.AreEqual(list1, list2, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Collections.AreEqual", "Failure message assertion name was not altered");
+            StringAssert.Matches(ex.Message, new Regex($".+{message}\\(.+\\.\\)$"), "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]

--- a/AssertAll.Tests/CollectionTests/AreEquivalentShould.cs
+++ b/AssertAll.Tests/CollectionTests/AreEquivalentShould.cs
@@ -13,9 +13,13 @@ namespace AssertAllTests.CollectionTests
         {
             var list1 = new List<string> {"1"};
             var list2 = new List<string> {"1", "2"};
-            AssertAll.Collections.AreEquivalent(list1, list2);
+            string message = "list items are different";
+            AssertAll.Collections.AreEquivalent(list1, list2, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Collections.AreEquivalent", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]

--- a/AssertAll.Tests/CollectionTests/AreNotEqualShould.cs
+++ b/AssertAll.Tests/CollectionTests/AreNotEqualShould.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using AssertAllNuget;
 using AssertAllNuget.Exceptions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -31,9 +32,13 @@ namespace AssertAllTests.CollectionTests
         {
             var list1 = new List<string> { "1", "2" };
             var list2 = new List<string> { "1", "2" };
-            AssertAll.Collections.AreNotEqual(list1, list2);
+            string message = "list items are the same and in the same order";
+            AssertAll.Collections.AreNotEqual(list1, list2, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Collections.AreNotEqual", "Failure message assertion name was not altered");
+            StringAssert.Matches(ex.Message, new Regex($".+{message}\\(.+\\.\\)$"), "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/CollectionTests/AreNotEquivalentShould.cs
+++ b/AssertAll.Tests/CollectionTests/AreNotEquivalentShould.cs
@@ -13,9 +13,13 @@ namespace AssertAllTests.CollectionTests
         {
             var list1 = new List<string> { "2", "1" };
             var list2 = new List<string> { "1", "2" };
-            AssertAll.Collections.AreNotEquivalent(list1, list2);
+            string message = "list items are the same";
+            AssertAll.Collections.AreNotEquivalent(list1, list2, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Collections.AreNotEquivalent", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]

--- a/AssertAll.Tests/CollectionTests/ContainsShould.cs
+++ b/AssertAll.Tests/CollectionTests/ContainsShould.cs
@@ -12,9 +12,13 @@ namespace AssertAllTests.CollectionTests
         public void FailWhenDoesNotContain()
         {
             var list1 = new List<string> {"1", "2"};
-            AssertAll.Collections.Contains(list1, "3");
+            string message = "item not found in list";
+            AssertAll.Collections.Contains(list1, "3", message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Collections.Contains", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]

--- a/AssertAll.Tests/CollectionTests/DoesNotContainShould.cs
+++ b/AssertAll.Tests/CollectionTests/DoesNotContainShould.cs
@@ -12,9 +12,13 @@ namespace AssertAllTests.CollectionTests
         public void FailWhenDoesContain()
         {
             var list1 = new List<string> {"1", "2"};
-            AssertAll.Collections.DoesNotContain(list1, "2");
+            string message = "item unexpectedly found in list";
+            AssertAll.Collections.DoesNotContain(list1, "2", message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Collections.DoesNotContain", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]

--- a/AssertAll.Tests/CollectionTests/IsNotSubsetOfShould.cs
+++ b/AssertAll.Tests/CollectionTests/IsNotSubsetOfShould.cs
@@ -13,9 +13,13 @@ namespace AssertAllTests.CollectionTests
         {
             var list1 = new List<string> {"1"};
             var list2 = new List<string> {"1", "2"};
-            AssertAll.Collections.IsNotSubsetOf(list1, list2);
+            string message = "list items unexpectedly found";
+            AssertAll.Collections.IsNotSubsetOf(list1, list2, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Collections.IsNotSubsetOf", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]

--- a/AssertAll.Tests/CollectionTests/IsSubsetOfShould.cs
+++ b/AssertAll.Tests/CollectionTests/IsSubsetOfShould.cs
@@ -13,9 +13,13 @@ namespace AssertAllTests.CollectionTests
         {
             var list1 = new List<string> {"1"};
             var list2 = new List<string> {"1", "2"};
-            AssertAll.Collections.IsSubsetOf(list2, list1);
+            string message = "list items missing";
+            AssertAll.Collections.IsSubsetOf(list2, list1, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Collections.IsSubsetOf", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, message, "Failure message missing or followed by unexpected text");
         }
 
         [TestMethod]

--- a/AssertAll.Tests/ExtensionMethodTests/ExceptionHasInnerExceptionAsyncShould.cs
+++ b/AssertAll.Tests/ExtensionMethodTests/ExceptionHasInnerExceptionAsyncShould.cs
@@ -23,29 +23,46 @@ namespace AssertAllTests.ExtensionMethodTests
         [TestMethod]
         public void FailWhenInnerExceptionIsNotCorrectType()
         {
+            string message = "unexpected inner exception";
             AssertAll.ThrowsExceptionWithInnerExceptionAsync<ArgumentException>(async () =>
-                await ThrowExceptionWithInnerInvalidOperationException(true));
+                await ThrowExceptionWithInnerInvalidOperationException(true), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(
+                    ex.Message,
+                    $"(1) AssertAll.ThrowsExceptionWithInnerExceptionAsync failed. Threw exception System.InvalidOperationException, but inner exception System.ArgumentException was expected. {message}\r\n",
+                    "Unexpected failure message");
         }
 
         [TestMethod]
         public void FailWhenNoExceptionIsThrown()
         {
-            var list = new List<object>() { new object() };
+            string message = "missing exception";
             AssertAll.ThrowsExceptionWithInnerExceptionAsync<InvalidOperationException>(async () =>
-                ThrowExceptionWithInnerInvalidOperationException(false));
+                await ThrowExceptionWithInnerInvalidOperationException(false), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            Assert.AreEqual(
+                    $"(1) AssertAll.ThrowsExceptionWithInnerExceptionAsync failed. No exception thrown. InvalidOperationException inner exception was expected. {message}",
+                    ex.Message,
+                    "Unexpected failure message");
         }
 
         [TestMethod]
         public void FailWhenInnerExceptionIsNull()
         {
+            string message = "missing inner exception";
             AssertAll.ThrowsExceptionWithInnerExceptionAsync<ArgumentException>(async () => 
-                await ThrowNewException());
+                await ThrowNewException(), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            Assert.AreEqual(
+                    $"(1) AssertAll.ThrowsExceptionWithInnerExceptionAsync failed. Thrown exception has no inner exception. ArgumentException inner exception was expected. {message}",
+                    ex.Message,
+                    "Unexpected failure message");
         }
 
 

--- a/AssertAll.Tests/ExtensionMethodTests/ExceptionHasInnerExceptionShould.cs
+++ b/AssertAll.Tests/ExtensionMethodTests/ExceptionHasInnerExceptionShould.cs
@@ -22,29 +22,46 @@ namespace AssertAllTests.ExtensionMethodTests
         [TestMethod]
         public void FailWhenInnerExceptionIsNotCorrectType()
         {
+            string message = "unexpected inner exception";
             AssertAll.ThrowsExceptionWithInnerException<ArgumentException>(() =>
-                ThrowExceptionWithInnerInvalidOperationException(true));
+                ThrowExceptionWithInnerInvalidOperationException(true), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(
+                    ex.Message,
+                    $"(1) AssertAll.ThrowsExceptionWithInnerException failed. Threw exception System.InvalidOperationException, but inner exception System.ArgumentException was expected. {message}\r\n",
+                    "Unexpected failure message");
         }
 
         [TestMethod]
         public void FailWhenNoExceptionIsThrown()
         {
-            var list = new List<object>() { new object() };
+            string message = "missing exception";
             AssertAll.ThrowsExceptionWithInnerException<InvalidOperationException>(() =>
-                ThrowExceptionWithInnerInvalidOperationException(false));
+                ThrowExceptionWithInnerInvalidOperationException(false), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            Assert.AreEqual(
+                    $"(1) AssertAll.ThrowsExceptionWithInnerException failed. No exception thrown. InvalidOperationException inner exception was expected. {message}",
+                    ex.Message,
+                    "Unexpected failure message");
         }
 
         [TestMethod]
         public void FailWhenInnerExceptionIsNull()
         {
+            string message = "missing inner exception";
             AssertAll.ThrowsExceptionWithInnerException<ArgumentException>(() => 
-                throw new Exception(RandomValue.String()));
+                throw new Exception(RandomValue.String()), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            Assert.AreEqual(
+                    $"(1) AssertAll.ThrowsExceptionWithInnerException failed. Thrown exception has no inner exception. ArgumentException inner exception was expected. {message}",
+                    ex.Message,
+                    "Unexpected failure message");
         }
 
 

--- a/AssertAll.Tests/ExtensionMethodTests/ExceptionMessageContainsAsyncShould.cs
+++ b/AssertAll.Tests/ExtensionMethodTests/ExceptionMessageContainsAsyncShould.cs
@@ -25,22 +25,34 @@ namespace AssertAllTests.ExtensionMethodTests
         public void FailWhenExceptionMessageDoesNotContainArgument()
         {
             var doesNotContain = RandomValue.String();
-            var message = RandomValue.String();
-            AssertAll.ExceptionMessageContainsAsync(async () => await ThrowExceptionWithMessage(message),
-                doesNotContain);
+            var exceptionMessage = RandomValue.String();
+            string assertFailureMessage = "unexpected exception message";
+            AssertAll.ExceptionMessageContainsAsync(async () => await ThrowExceptionWithMessage(exceptionMessage),
+                doesNotContain, assertFailureMessage);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            Assert.AreEqual(
+                    $"(1) AssertAll.ExceptionMessageContainsAsync failed. {exceptionMessage} does not contain {doesNotContain}. {assertFailureMessage}",
+                    ex.Message,
+                    "Unexpected failure message");
         }
 
         [TestMethod]
         public void FailWhenExceptionIsNotThrown()
         {
             var doesNotContain = RandomValue.String();
-            var message = RandomValue.String();
-            AssertAll.ExceptionMessageContainsAsync(async () => await ThrowExceptionWithMessage(message, false),
-                doesNotContain);
+            var exceptionMessage = RandomValue.String();
+            string assertFailureMessage = "missing exception";
+            AssertAll.ExceptionMessageContainsAsync(async () => await ThrowExceptionWithMessage(exceptionMessage, false),
+                doesNotContain, assertFailureMessage);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            Assert.AreEqual(
+                    $"(1) AssertAll.ExceptionMessageContainsAsync failed. No exception thrown. {assertFailureMessage}",
+                    ex.Message,
+                    "Unexpected failure message");
         }
 
         private async Task ThrowExceptionWithMessage(string message, bool shouldThrow = true)

--- a/AssertAll.Tests/ExtensionMethodTests/ExceptionMessageContainsShould.cs
+++ b/AssertAll.Tests/ExtensionMethodTests/ExceptionMessageContainsShould.cs
@@ -24,22 +24,34 @@ namespace AssertAllTests.ExtensionMethodTests
         public void FailWhenExceptionMessageDoesNotContainArgument()
         {
             var doesNotContain = RandomValue.String();
-            var message = RandomValue.String();
-            AssertAll.ExceptionMessageContains(() => ThrowExceptionWithMessage(message),
-                doesNotContain);
+            var exceptionMessage = RandomValue.String();
+            string assertFailureMessage = "unexpected exception message";
+            AssertAll.ExceptionMessageContains(() => ThrowExceptionWithMessage(exceptionMessage),
+                doesNotContain, assertFailureMessage);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            Assert.AreEqual(
+                    $"(1) AssertAll.ExceptionMessageContains failed. {exceptionMessage} does not contain {doesNotContain}. {assertFailureMessage}",
+                    ex.Message,
+                    "Unexpected failure message");
         }
 
         [TestMethod]
         public void FailWhenExceptionIsNotThrown()
         {
             var notEqual = RandomValue.String();
-            var message = RandomValue.String();
-            AssertAll.ExceptionMessageContains(() => ThrowExceptionWithMessage(message, false),
-                notEqual);
+            var exceptionMessage = RandomValue.String();
+            string assertFailureMessage = "missing exception";
+            AssertAll.ExceptionMessageContains(() => ThrowExceptionWithMessage(exceptionMessage, false),
+                notEqual, assertFailureMessage);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            Assert.AreEqual(
+                    $"(1) AssertAll.ExceptionMessageContains failed. No exception thrown. {assertFailureMessage}",
+                    ex.Message,
+                    "Unexpected failure message");
         }
 
         private void ThrowExceptionWithMessage(string message, bool shouldThrow = true)

--- a/AssertAll.Tests/ExtensionMethodTests/ExceptionMessageEqualsAsyncShould.cs
+++ b/AssertAll.Tests/ExtensionMethodTests/ExceptionMessageEqualsAsyncShould.cs
@@ -24,11 +24,17 @@ namespace AssertAllTests.ExtensionMethodTests
         public void FailWhenExceptionMessageDoesNotEqualArgument()
         {
             var notEqual = RandomValue.String();
-            var message = RandomValue.String();
-            AssertAll.ExceptionMessageEqualsAsync(async () => await ThrowExceptionWithMessage(message),
-                notEqual);
+            var exceptionMessage = RandomValue.String();
+            string assertFailureMessage = "unexpected exception message";
+            AssertAll.ExceptionMessageEqualsAsync(async () => await ThrowExceptionWithMessage(exceptionMessage),
+                notEqual, assertFailureMessage);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            Assert.AreEqual(
+                    $"(1) AssertAll.ExceptionMessageEqualsAsync failed. Expected message: {notEqual} Actual message: {exceptionMessage}. {assertFailureMessage}",
+                    ex.Message,
+                    "Unexpected failure message");
         }
         
         [TestMethod]
@@ -36,10 +42,16 @@ namespace AssertAllTests.ExtensionMethodTests
         {
             var notEqual = RandomValue.String();
             var message = RandomValue.String();
+            string assertFailureMessage = "missing exception";
             AssertAll.ExceptionMessageEqualsAsync(() => ThrowExceptionWithMessage(message, false),
-                notEqual);
+                notEqual, assertFailureMessage);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            Assert.AreEqual(
+                    $"(1) AssertAll.ExceptionMessageEqualsAsync failed. No exception thrown. {assertFailureMessage}",
+                    ex.Message,
+                    "Unexpected failure message");
         }
 
         private async Task ThrowExceptionWithMessage(string message, bool shouldThrow = true)

--- a/AssertAll.Tests/ExtensionMethodTests/ExceptionMessageEqualsShould.cs
+++ b/AssertAll.Tests/ExtensionMethodTests/ExceptionMessageEqualsShould.cs
@@ -23,22 +23,34 @@ namespace AssertAllTests.ExtensionMethodTests
         public void FailWhenExceptionMessageDoesNotEqualArgument()
         {
             var notEqual = RandomValue.String();
-            var message = RandomValue.String();
-            AssertAll.ExceptionMessageEquals(() => ThrowExceptionWithMessage(message),
-                notEqual);
+            var exceptionMessage = RandomValue.String();
+            string assertFailureMessage = "unexpected exception message";
+            AssertAll.ExceptionMessageEquals(() => ThrowExceptionWithMessage(exceptionMessage),
+                notEqual, assertFailureMessage);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            Assert.AreEqual(
+                    $"(1) AssertAll.ExceptionMessageEquals failed. Expected message: {notEqual} Actual message: {exceptionMessage}. {assertFailureMessage}",
+                    ex.Message,
+                    "Unexpected failure message");
         }
 
         [TestMethod]
         public void FailWhenExceptionIsNotThrown()
         {
             var notEqual = RandomValue.String();
-            var message = RandomValue.String();
-            AssertAll.ExceptionMessageEquals(() => ThrowExceptionWithMessage(message, false),
-                notEqual);
+            var exceptionMessage = RandomValue.String();
+            string assertFailureMessage = "missing exception";
+            AssertAll.ExceptionMessageEquals(() => ThrowExceptionWithMessage(exceptionMessage, false),
+                notEqual, assertFailureMessage);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            Assert.AreEqual(
+                    $"(1) AssertAll.ExceptionMessageEquals failed. No exception thrown. {assertFailureMessage}",
+                    ex.Message,
+                    "Unexpected failure message");
         }
 
         private void ThrowExceptionWithMessage(string message, bool shouldThrow = true)

--- a/AssertAll.Tests/ExtensionMethods/CollectionContainsExtensions.cs
+++ b/AssertAll.Tests/ExtensionMethods/CollectionContainsExtensions.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+
+namespace AssertAllTests.ExtensionMethods
+{
+    internal static class CollectionContainsExtensions
+    {
+        private const int NO_MATCH_FOUND = -1;
+        private const int MATCHES_COLLISIONS_FOUND = -2;
+
+        internal static void ArrayHasDiscreteStringsContaining(this Assert source, string[] substringsExpected, string[] stringsActual, bool matchCase = false, string message = null)
+        {
+            int[] matchIndexes = new int[substringsExpected.Length];
+            Array.Fill(matchIndexes, NO_MATCH_FOUND);
+
+            for (int expectedSubstringIndex = 0; expectedSubstringIndex < substringsExpected.Length; expectedSubstringIndex++)
+            {
+                for (int actualStringIndex = 0; actualStringIndex < stringsActual.Length; actualStringIndex++)
+                {
+                    string actual = stringsActual[actualStringIndex];
+                    string expected = substringsExpected[expectedSubstringIndex];
+                    if (actual.Contains(expected, matchCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (matchIndexes[expectedSubstringIndex] == NO_MATCH_FOUND && !matchIndexes.Contains(actualStringIndex))
+                        {
+                            matchIndexes[expectedSubstringIndex] = actualStringIndex;
+                        }
+                        else
+                        {
+                            matchIndexes[expectedSubstringIndex] = MATCHES_COLLISIONS_FOUND;
+                        }
+                    }
+                }
+            }
+
+            string failureMessage = "";
+            for (int index = 0; index < matchIndexes.Length; index++) {
+                if (matchIndexes[index] == NO_MATCH_FOUND)
+                {
+                    failureMessage += $"\r\nNo string found containing substring '{substringsExpected[index]}'";
+                }
+                if (matchIndexes[index] == MATCHES_COLLISIONS_FOUND)
+                {
+                    failureMessage += $"\r\nSubstring '{substringsExpected[index]}' either appeared repeatedly or in the same element as another substring";
+                }
+            }
+
+            if (failureMessage.Length > 0)
+            {
+                throw new AssertFailedException($"Assert.ArrayHasDiscreteStringsContaining failed.{failureMessage}\r\n{message}");
+            }
+        }
+
+        internal static void ArrayLacksStringContaining(this Assert source, string substringExpected, string[] arrayActual, bool matchCase = false, string message = null)
+        {
+            bool substringFound = false;
+            foreach (string actual in arrayActual)
+            {
+                if (actual.Contains(substringExpected, matchCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase))
+                {
+                    substringFound = true;
+                    break;
+                }
+            }
+
+            if (substringFound)
+            {
+                throw new AssertFailedException($"Assert.ArrayLacksStringContaining failed. {substringExpected} was a substring of an element in the array. {message}");
+            }
+        }
+    }
+}

--- a/AssertAll.Tests/StringTests/ContainsShould.cs
+++ b/AssertAll.Tests/StringTests/ContainsShould.cs
@@ -22,9 +22,13 @@ namespace AssertAllTests.StringTests
         [TestMethod]
         public void FailWhenDoesNotContain()
         {
-            AssertAll.Strings.Contains(RandomValue.String(), RandomValue.String());
+            string message = "substring not found";
+            AssertAll.Strings.Contains(RandomValue.String(), RandomValue.String(), message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Strings.Contains", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, $"{message}.", "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/StringTests/DoesNotMatchShould.cs
+++ b/AssertAll.Tests/StringTests/DoesNotMatchShould.cs
@@ -24,9 +24,13 @@ namespace AssertAllTests.StringTests
         {
             var someString = RandomValue.Int().ToString();
             var pattern = new Regex("[0-9]");
-            AssertAll.Strings.DoesNotMatch(someString, pattern);
+            string message = "strings match";
+            AssertAll.Strings.DoesNotMatch(someString, pattern, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Strings.DoesNotMatch", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, $"{message}.", "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/StringTests/EndsWithShould.cs
+++ b/AssertAll.Tests/StringTests/EndsWithShould.cs
@@ -24,10 +24,14 @@ namespace AssertAllTests.StringTests
         {
             var value = RandomValue.String();
             var substring = RandomValue.String();
+            string message = "string doesn't end with";
 
-            AssertAll.Strings.EndsWith(value, substring);
+            AssertAll.Strings.EndsWith(value, substring, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Strings.EndsWith", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, $"{message}.", "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/StringTests/MatchesShould.cs
+++ b/AssertAll.Tests/StringTests/MatchesShould.cs
@@ -24,9 +24,13 @@ namespace AssertAllTests.StringTests
         {
             var someString = RandomValue.Int().ToString();
             var pattern = new Regex("[a-z]");
-            AssertAll.Strings.Matches(someString, pattern);
+            string message = "strings don't match";
+            AssertAll.Strings.Matches(someString, pattern, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Strings.Matches", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, $"{message}.", "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll.Tests/StringTests/StartsWithShould.cs
+++ b/AssertAll.Tests/StringTests/StartsWithShould.cs
@@ -24,10 +24,14 @@ namespace AssertAllTests.StringTests
         {
             var value = RandomValue.String();
             var differentValue = RandomValue.String();
+            string message = "string doesn't start with";
 
-            AssertAll.Strings.StartsWith(value, differentValue);
+            AssertAll.Strings.StartsWith(value, differentValue, message);
 
-            Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            AssertAllFailedException ex =
+                    Assert.ThrowsException<AssertAllFailedException>(() => AssertAll.Execute());
+            StringAssert.StartsWith(ex.Message, $"(1) AssertAll.Strings.StartsWith", "Failure message assertion name was not altered");
+            StringAssert.EndsWith(ex.Message, $"{message}.", "Failure message missing or followed by unexpected text");
         }
     }
 }

--- a/AssertAll/AssertAll.cs
+++ b/AssertAll/AssertAll.cs
@@ -107,6 +107,10 @@ namespace AssertAllNuget
                     {
                         replaced = assertException.Message.Replace("CollectionAssert.", "AssertAll.Collections.");
                     }
+                    else if(assertException.Message.Contains("StringAssert"))
+                    {
+                        replaced = assertException.Message.Replace("StringAssert.", "AssertAll.Strings.");
+                    }
                     else
                     {
                         replaced = assertException.Message.Replace("Assert.", "AssertAll.");
@@ -115,7 +119,7 @@ namespace AssertAllNuget
                     counter++;
                 }
 
-                var bigMessage = string.Join(" ", allMessages);
+                var bigMessage = string.Join(Environment.NewLine, allMessages);
                 var stackTrace = string.Join(Environment.NewLine, stackTraceItems);
                 
                 if (failure)
@@ -173,7 +177,7 @@ namespace AssertAllNuget
             }
             else
             {
-                RegisterAction(() => Assert.AreNotSame(notExpected, actual));
+                RegisterAction(() => Assert.AreNotSame(notExpected, actual, message));
             }
         }
 

--- a/AssertAll/ExtensionMethods/ThrowsExceptionExtensions.cs
+++ b/AssertAll/ExtensionMethods/ThrowsExceptionExtensions.cs
@@ -76,7 +76,7 @@ namespace AssertAllNuget.ExtensionMethods
 
             if (thrownException.Message != equals)
             {
-                throw new AssertFailedException($"Assert.ExceptionMessageEquals failed. Actual message: {thrownException.Message}. {message}");
+                throw new AssertFailedException($"Assert.ExceptionMessageEquals failed. Expected message: {equals} Actual message: {thrownException.Message}. {message}");
             }
         }
 
@@ -150,7 +150,7 @@ namespace AssertAllNuget.ExtensionMethods
 
             if (thrownException.Message != equals)
             {
-                throw new AssertFailedException($"Assert.ExceptionMessageEqualsAsync failed. Actual message: {thrownException.Message}. {message}");
+                throw new AssertFailedException($"Assert.ExceptionMessageEqualsAsync failed. Expected message: {equals} Actual message: {thrownException.Message}. {message}");
             }
         }
     }


### PR DESCRIPTION
Updates test coverage to verify individual failure message presentation
Updates AssertAll.Execute to put each failure message on its own line, verifies with test.
Adds TODO comment and an Assert.Inconclusive to a brittle test whose SUT appears incomplete.